### PR TITLE
feat: add npm publish config

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "Load multiple dotenv style environment files.",
   "main": "dist/index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\"",
     "prepublish": "yarn clean && yarn compile",


### PR DESCRIPTION
Adds npm publish config set to public access.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.1-canary.3.40.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/multienv@1.0.1-canary.3.40.0
  # or 
  yarn add @artsy/multienv@1.0.1-canary.3.40.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
