### PR TITLE
feature: Orb Support Main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   yarn: artsy/yarn@6.0.0
-  auto: artsy/auto@1.4.0
+  auto: artsy/auto@2.0.0
 
 workflows:
   build_and_verify:


### PR DESCRIPTION
Bumps the auto orb so that it supports publishing from main.